### PR TITLE
fix: k3s cluster vips

### DIFF
--- a/modules/k3s-cluster/provision/ansible/playbook.yaml
+++ b/modules/k3s-cluster/provision/ansible/playbook.yaml
@@ -21,12 +21,6 @@
     - role: k3s
     - role: calico
     - role: metallb
-      vars:
-        metallb_addresses:
-          - name: api-server
-            ip: "{{ cluster_api_vip }}"
-          - name: ingress
-            ip: "{{ cluster_ingress_vip }}"
     - role: endpoint_copier
   environment:
     KUBECONFIG: /etc/rancher/k3s/k3s.yaml

--- a/modules/k3s-cluster/provision/ansible/requirements.yaml
+++ b/modules/k3s-cluster/provision/ansible/requirements.yaml
@@ -1,8 +1,10 @@
 ---
 collections:
   - name: ansible.posix
+    source: https://github.com//ansible-collections/ansible.posix.git
+    type: git
     version: 2.0.0
   - name: kubernetes.core
-    version: 5.0.0
-  - name: cloud.terraform
-    version: 3.0.0
+    source: https://github.com/ansible-collections/kubernetes.core.git
+    type: git
+    version: 6.0.0

--- a/modules/k3s-cluster/provision/ansible/roles/metallb/tasks/main.yaml
+++ b/modules/k3s-cluster/provision/ansible/roles/metallb/tasks/main.yaml
@@ -41,27 +41,56 @@
       type: Available
     wait_timeout: 90
 
-- name: Metallb AddressPool
+- name: Metallb kube-apiserver AddressPool
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: metallb.io/v1beta1
       kind: IPAddressPool
       metadata:
-        name: "{{ item.name }}"
+        name: api-pool
         namespace: metallb-system
       spec:
         addresses:
-          - "{{ item.ip }}/32"
-  loop: "{{ metallb_addresses }}"
+          - "{{ cluster_api_vip }}/32"
 
-- name: Metallb L2Advertisement
+- name: Metallb Ingress AddressPool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: ingress-pool
+        namespace: metallb-system
+      spec:
+        addresses:
+          - "{{ cluster_ingress_vip }}/32"
+  when: cluster_ingress_vip != ""
+
+- name: Metallb kube-apiserver L2Advertisement
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: metallb.io/v1beta1
       kind: L2Advertisement
       metadata:
-        name: "{{ item.name }}"
+        name: api-advertisement
         namespace: metallb-system
-  loop: "{{ metallb_addresses }}"
+      spec:
+        ipAddressPools:
+          - api-pool
+
+- name: Metallb Ingress L2Advertisement
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: ingress-advertisement
+        namespace: metallb-system
+      spec:
+        ipAddressPools:
+          - ingress-pool
+  when: cluster_ingress_vip != ""

--- a/modules/vault-k8s-config/requirements.yaml
+++ b/modules/vault-k8s-config/requirements.yaml
@@ -1,6 +1,10 @@
 ---
 collections:
   - name: kubernetes.core
-    version: 5.0.0
+    source: https://github.com/ansible-collections/kubernetes.core.git
+    type: git
+    version: 6.0.0
   - name: community.hashi_vault # spellchecker:disable-line
+    source: https://github.com/ansible-collections/community.hashi_vault.git
+    type: git
     version: 6.2.0


### PR DESCRIPTION
Changes:

- Make ingress vip optional
- Use `git` as the source when installing Ansible collections